### PR TITLE
Fix permission issue on kanban task

### DIFF
--- a/urbanvitaliz/apps/projects/models.py
+++ b/urbanvitaliz/apps/projects/models.py
@@ -317,7 +317,7 @@ class TaskManager(OrderedModelManager):
 
     def published(self):
         return self.filter(public=True)
-    
+
     def unpublished_open(self):
         return self.unpublished_proposed() | self.filter(status=Task.INPROGRESS)
 

--- a/urbanvitaliz/apps/projects/signals.py
+++ b/urbanvitaliz/apps/projects/signals.py
@@ -14,10 +14,14 @@ from urbanvitaliz.apps.reminders import models as reminders_models
 from urbanvitaliz.apps.survey import signals as survey_signals
 
 from . import models
-from .utils import (create_reminder, get_collaborators_for_project,
-                    get_notification_recipients_for_project,
-                    get_project_moderators, get_regional_actors_for_project,
-                    get_switchtenders_for_project)
+from .utils import (
+    create_reminder,
+    get_collaborators_for_project,
+    get_notification_recipients_for_project,
+    get_project_moderators,
+    get_regional_actors_for_project,
+    get_switchtenders_for_project,
+)
 
 #####
 # Projects

--- a/urbanvitaliz/apps/projects/views/rest.py
+++ b/urbanvitaliz/apps/projects/views/rest.py
@@ -120,8 +120,9 @@ class TaskViewSet(viewsets.ModelViewSet):
             models.Project.objects.for_user(self.request.user).values_list(flat=True)
         )
 
-        if project_id not in user_projects:
-            raise PermissionDenied()
+        # FIXME : Disabling authorisation here, we need something to secure the whole api
+        # if project_id not in user_projects:
+        #     raise PermissionDenied()
 
         return models.Task.objects.filter(project_id=project_id).order_by(
             "-created_on", "-updated_on"

--- a/urbanvitaliz/apps/projects/views/tasks.py
+++ b/urbanvitaliz/apps/projects/views/tasks.py
@@ -17,16 +17,25 @@ from urbanvitaliz.apps.reminders import api
 from urbanvitaliz.apps.reminders import models as reminders_models
 from urbanvitaliz.apps.resources import models as resources
 from urbanvitaliz.apps.survey import models as survey_models
-from urbanvitaliz.utils import (check_if_switchtender, is_staff_or_403,
-                                is_switchtender_or_403)
+from urbanvitaliz.utils import (
+    check_if_switchtender,
+    is_staff_or_403,
+    is_switchtender_or_403,
+)
 
 from .. import models, signals
-from ..forms import (CreateActionsFromResourcesForm,
-                     CreateActionWithoutResourceForm,
-                     CreateActionWithResourceForm, PushTypeActionForm,
-                     RemindTaskForm, RsvpTaskFollowupForm, TaskFollowupForm,
-                     TaskRecommendationForm, UpdateTaskFollowupForm,
-                     UpdateTaskForm)
+from ..forms import (
+    CreateActionsFromResourcesForm,
+    CreateActionWithoutResourceForm,
+    CreateActionWithResourceForm,
+    PushTypeActionForm,
+    RemindTaskForm,
+    RsvpTaskFollowupForm,
+    TaskFollowupForm,
+    TaskRecommendationForm,
+    UpdateTaskFollowupForm,
+    UpdateTaskForm,
+)
 from ..utils import can_manage_or_403, create_reminder, get_active_project_id
 
 


### PR DESCRIPTION
When a switchtender, but not one assigned to a project, they can't see the list of recommended actions.

I've removed the auth check in the REST api, but we may need a more robust security strategy for the api