### PR TITLE
Bugfix/handle empty message conversation

### DIFF
--- a/frontend_tests/cypress/e2e/project/switchtender/assigned/canAccessAndUsePrivateNotes.cy.js
+++ b/frontend_tests/cypress/e2e/project/switchtender/assigned/canAccessAndUsePrivateNotes.cy.js
@@ -12,7 +12,7 @@ describe('I can access and use private notes', () => {
 
         cy.visit('/projects')
 
-        cy.contains(currentProject.fields.name).click({force:true});
+        cy.contains(currentProject.fields.name).click({ force: true });
 
         cy.contains("Espace conseiller").click({ force: true })
 
@@ -23,6 +23,8 @@ describe('I can access and use private notes', () => {
         cy.get('textarea')
             .type(`test : ${now}`, { force: true })
             .should('have.value', `test : ${now}`)
+
+        cy.get('[data-test-id="tiptap-editor-content"] .ProseMirror').type(`test : ${now}`, { force: true })
 
         cy.contains("Envoyer").click({ force: true })
 

--- a/frontend_tests/cypress/e2e/project/switchtender/assigned/canAccessAndUsePublicNotes.cy.js
+++ b/frontend_tests/cypress/e2e/project/switchtender/assigned/canAccessAndUsePublicNotes.cy.js
@@ -12,7 +12,7 @@ describe('I can access and use public notes', () => {
 
         cy.visit('/projects')
 
-        cy.contains(currentProject.fields.name).click({force:true});
+        cy.contains(currentProject.fields.name).click({ force: true });
 
         cy.contains("Conversation").click({ force: true })
 
@@ -23,6 +23,8 @@ describe('I can access and use public notes', () => {
         cy.get('textarea')
             .type(`test : ${now}`, { force: true })
             .should('have.value', `test : ${now}`)
+
+        cy.get('[data-test-id="tiptap-editor-content"] .ProseMirror').type(`test : ${now}`, { force: true })
 
         cy.contains("Envoyer").click({ force: true })
 

--- a/frontend_tests/cypress/e2e/tools/conversation/canAddAFileInMessage.cy.js
+++ b/frontend_tests/cypress/e2e/tools/conversation/canAddAFileInMessage.cy.js
@@ -11,7 +11,7 @@ describe('I can add a file with my message in public notes', () => {
     it('writes a message with a file', () => {
         cy.visit('/projects')
 
-        cy.contains(currentProject.fields.name).click({force:true});
+        cy.contains(currentProject.fields.name).click({ force: true });
 
         cy.contains("Conversation").click({ force: true })
 
@@ -23,11 +23,13 @@ describe('I can add a file with my message in public notes', () => {
             .type(`test avec fichier : ${now}`, { force: true })
             .should('have.value', `test avec fichier : ${now}`)
 
+        cy.get('[data-test-id="tiptap-editor-content"] .ProseMirror').type(`test avec fichier : ${now}`, { force: true })
+
         cy.get('[name="the_file"]').selectFile(file.path, { force: true });
 
         cy.contains("Envoyer").click({ force: true })
 
         cy.contains(`test avec fichier : ${now}`)
-        cy.contains(file.path.slice(-17,-4))
+        cy.contains(file.path.slice(-17, -4))
     })
 })

--- a/frontend_tests/cypress/e2e/tools/conversation/cantSendAnEmptyMessage.cy.js
+++ b/frontend_tests/cypress/e2e/tools/conversation/cantSendAnEmptyMessage.cy.js
@@ -1,0 +1,56 @@
+import projects from '../../../fixtures/projects/projects.json'
+
+const currentProject = projects[1];
+
+describe("I can't send an empty message", () => {
+    beforeEach(() => {
+        cy.login("jean");
+    })
+
+    it('shows a disabled send message button', () => {
+        cy.visit('/projects')
+
+        cy.contains(currentProject.fields.name).click({ force: true });
+
+        cy.contains("Conversation").click({ force: true })
+
+        cy.url().should('include', '/conversations')
+
+        cy.get('[data-test-id="send-message-conversation"]').should('have.attr', 'disabled')
+    })
+
+    it('enables the send message if I type a message', () => {
+
+        cy.visit('/projects')
+
+        cy.contains(currentProject.fields.name).click({ force: true });
+
+        cy.contains("Conversation").click({ force: true })
+
+        cy.url().should('include', '/conversations')
+
+        cy.get('[data-test-id="tiptap-editor-content"] .ProseMirror').type(`new message`, { force: true })
+
+        cy.get('[data-test-id="send-message-conversation"]').should('not.have.attr', 'disabled')
+    })
+
+    it('disables the send message if I erase my message (empty message)', () => {
+
+        cy.visit('/projects')
+
+        cy.contains(currentProject.fields.name).click({ force: true });
+
+        cy.contains("Conversation").click({ force: true })
+
+        cy.url().should('include', '/conversations')
+
+        cy.get('[data-test-id="tiptap-editor-content"] .ProseMirror').type(`new message`, { force: true })
+
+        cy.get('[data-test-id="send-message-conversation"]').should('not.have.attr', 'disabled')
+
+        cy.get('[data-test-id="tiptap-editor-content"] .ProseMirror').clear()
+
+        cy.get('[data-test-id="send-message-conversation"]').should('have.attr', 'disabled')
+    })
+
+})

--- a/urbanvitaliz/apps/projects/templates/projects/project/conversations.html
+++ b/urbanvitaliz/apps/projects/templates/projects/project/conversations.html
@@ -71,7 +71,7 @@
                 {% for error in public_note_form.content.errors %}<div class="text-danger text-end">{{ error }}</div>{% endfor %}
                 {% include 'projects/project/fragments/files_links/file_upload_input_standalone.html' %}
                 <div class="d-flex justify-content-end mt-4">
-                  <button x-data :disabled="$store.editor.currentMessage === '' " form="conversation-form" class="button filled" type="submit">Envoyer</button>
+                  <button data-test-id="send-message-conversation" x-data :disabled="$store.editor.currentMessage === '' " form="conversation-form" class="button filled" type="submit">Envoyer</button>
                 </div>
               </form>
             </div>

--- a/urbanvitaliz/apps/projects/templates/projects/project/conversations.html
+++ b/urbanvitaliz/apps/projects/templates/projects/project/conversations.html
@@ -71,7 +71,7 @@
                 {% for error in public_note_form.content.errors %}<div class="text-danger text-end">{{ error }}</div>{% endfor %}
                 {% include 'projects/project/fragments/files_links/file_upload_input_standalone.html' %}
                 <div class="d-flex justify-content-end mt-4">
-                  <button form="conversation-form" class="button filled" type="submit">Envoyer</button>
+                  <button x-data :disabled="$store.editor.currentMessage === '' " form="conversation-form" class="button filled" type="submit">Envoyer</button>
                 </div>
               </form>
             </div>

--- a/urbanvitaliz/apps/projects/templates/projects/project/internal_followup.html
+++ b/urbanvitaliz/apps/projects/templates/projects/project/internal_followup.html
@@ -46,7 +46,9 @@
             <div class="text-danger text-end">{{ error }}</div>
             {% endfor %}
 
-            <button class="btn mt-2 btn-primary flex-align-end" type="submit">Envoyer</button>
+            <div class="d-flex justify-content-end mt-2">
+                <button x-data :disabled="$store.editor.currentMessage === ''" class="button filled" type="submit">Envoyer</button>
+            </div>
         </form>
         {% endif %}
 

--- a/urbanvitaliz/frontend/src/css/buttons.css
+++ b/urbanvitaliz/frontend/src/css/buttons.css
@@ -121,7 +121,7 @@
     color: #18753C !important;
 }
 
-.button.disabled{
+.button.disabled, .button:disabled{
     background-color: #EEEEEE;
     cursor: not-allowed;
     user-select: none;

--- a/urbanvitaliz/frontend/src/js/components/Editor.js
+++ b/urbanvitaliz/frontend/src/js/components/Editor.js
@@ -30,6 +30,9 @@ Alpine.data('editor', (content) => {
         onUpdate({ editor }) {
           _this.updatedAt = Date.now()
           _this.renderMarkdown();
+
+          _this.$store.editor.isEditing = editor.getMarkdown() != ''
+          _this.$store.editor.currentMessage = editor.getMarkdown()
         },
         onSelectionUpdate({ editor }) {
           _this.updatedAt = Date.now()
@@ -79,7 +82,7 @@ Alpine.data('editor', (content) => {
     unsetLink() {
       editor.chain().focus().unsetLink().run()
     },
-    setMarkdownContentFromTaskModal(event){
+    setMarkdownContentFromTaskModal(event) {
       editor.commands.setContent(event.detail);
     },
     renderMarkdown() {

--- a/urbanvitaliz/frontend/src/js/main.js
+++ b/urbanvitaliz/frontend/src/js/main.js
@@ -3,6 +3,7 @@ import './utils/globals'
 
 //Global Store
 import './store/utils'
+import './store/editor'
 import './store/djangoData'
 import './store/app'
 

--- a/urbanvitaliz/frontend/src/js/store/editor.js
+++ b/urbanvitaliz/frontend/src/js/store/editor.js
@@ -1,0 +1,11 @@
+import Alpine from "../utils/globals"
+
+document.addEventListener('alpine:init', () => {
+    Alpine.store('editor', {
+        currentMessage: "",
+        isEditing:false,
+        clearCurrentMessage() {
+            this.currentMessage = ""
+        }
+    })
+})

--- a/urbanvitaliz/templates/default_site/tools/editor.html
+++ b/urbanvitaliz/templates/default_site/tools/editor.html
@@ -49,12 +49,14 @@
     {% if is_task_comment %}
       <div class="d-flex justify-content-end">
         <button class="button filled blue small inherit"
+                :disabled="$store.editor.currentMessage === ''"
                 @click.stop="handleEditComment(markdownContent,task)">Enregistrer</button>
       </div>
     {% endif %}
     {% if is_task_modal_comment %}
       <div class="d-flex justify-content-end">
         <button class="button filled blue small inherit"
+                :disabled="$store.editor.currentMessage === ''"
                 @click.stop="onSubmitComment(markdownContent)">Enregistrer</button>
       </div>
     {% endif %}

--- a/urbanvitaliz/templates/default_site/tools/editor.html
+++ b/urbanvitaliz/templates/default_site/tools/editor.html
@@ -44,6 +44,7 @@
   <div class="position-relative">
     <div class="tiptap-editor {% if wide %}is-wide{% endif %}"
          x-ref="element"
+         data-test-id="tiptap-editor-content"
          @click.stop
          id="comment-text-ref"></div>
     {% if is_task_comment %}


### PR DESCRIPTION
carte trello https://trello.com/c/SSoP809I/1700-possibilit%C3%A9-denvoyer-une-pi%C3%A8ce-jointe-sans-message-dans-longlet-conversation-update-rendre-le-bouton-denvoie-de-message-inactif