### PR TITLE
[Project] Administration tab changed to `Paramètres` tab

### DIFF
--- a/frontend_tests/cypress/e2e/project/navigation/canAccessAdministration.cy.js
+++ b/frontend_tests/cypress/e2e/project/navigation/canAccessAdministration.cy.js
@@ -11,7 +11,7 @@ describe('I can access administration tab in a project as staff', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
         // cy.contains('Administration').click({ force: true })
-        cy.get('.project-navigation').children('li').contains('Administration').click({force:true})
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
     })
 })

--- a/frontend_tests/cypress/e2e/project/staff/administration/canChangeProjectInformation.cy.js
+++ b/frontend_tests/cypress/e2e/project/staff/administration/canChangeProjectInformation.cy.js
@@ -10,7 +10,7 @@ describe('I can go to administration area of a project and change general inform
     it('goes to the administration tab of a project general information', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.get('#id_name')

--- a/frontend_tests/cypress/e2e/project/staff/administration/canChangeProjectLocation.cy.js
+++ b/frontend_tests/cypress/e2e/project/staff/administration/canChangeProjectLocation.cy.js
@@ -13,7 +13,7 @@ describe('I can go to administration area of a project and change the project lo
     it('goes to the administration tab of a project and change the project location', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.get('#input-project-address')

--- a/frontend_tests/cypress/e2e/project/staff/administration/canInviteAMember.cy.js
+++ b/frontend_tests/cypress/e2e/project/staff/administration/canInviteAMember.cy.js
@@ -12,7 +12,7 @@ describe('I can go to administration area of a project and invite a member', () 
     it('goes to the administration tab of a project and invite a member', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.contains('Inviter un membre de la collectivité').click({ force: true });

--- a/frontend_tests/cypress/e2e/project/staff/administration/canInviteASwitchtender.cy.js
+++ b/frontend_tests/cypress/e2e/project/staff/administration/canInviteASwitchtender.cy.js
@@ -12,7 +12,7 @@ describe('I can go to administration area of a project and invite a switchtender
     it('goes to the administration tab of a project and invite a switchtender', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.contains('Inviter un conseiller').click({ force: true });

--- a/frontend_tests/cypress/e2e/project/staff/administration/canResendAMemberInvitation.cy.js
+++ b/frontend_tests/cypress/e2e/project/staff/administration/canResendAMemberInvitation.cy.js
@@ -12,7 +12,7 @@ describe('I can go to administration area of a project and send back an invite f
     it('goes to the administration tab of a project and send back the member invitation', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.contains('Inviter un membre de la collectivité').click({ force: true });

--- a/frontend_tests/cypress/e2e/project/staff/administration/canResendASwitchtenderInvitation.cy.js
+++ b/frontend_tests/cypress/e2e/project/staff/administration/canResendASwitchtenderInvitation.cy.js
@@ -12,7 +12,7 @@ describe('I can go to administration area of a project and send back an invite f
     it('goes to the administration tab of a project and send back the switchtender invitation', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.contains('Inviter un conseiller').click({ force: true });

--- a/frontend_tests/cypress/e2e/project/staff/administration/canRevokeAMemberInvitation.cy.js
+++ b/frontend_tests/cypress/e2e/project/staff/administration/canRevokeAMemberInvitation.cy.js
@@ -12,7 +12,7 @@ describe('I can go to administration area of a project and revoke an invite for 
     it('goes to the administration tab of a project and revoke the member invitation', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.contains('Inviter un membre de la collectivité').click({ force: true });

--- a/frontend_tests/cypress/e2e/project/staff/administration/canRevokeASwitchtenderInvitation.cy.js
+++ b/frontend_tests/cypress/e2e/project/staff/administration/canRevokeASwitchtenderInvitation.cy.js
@@ -12,7 +12,7 @@ describe('I can go to administration area of a project and revoke an invite for 
     it('goes to the administration tab of a project and revoke the switchtender invitation', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.contains('Inviter un conseiller').click({ force: true });

--- a/frontend_tests/cypress/e2e/project/switchtender/assigned/administration/canResendAMemberInvitation.cy.js
+++ b/frontend_tests/cypress/e2e/project/switchtender/assigned/administration/canResendAMemberInvitation.cy.js
@@ -10,7 +10,7 @@ describe('I can go to administration area of a project and send back an invite f
     it('goes to the administration tab of a project and send back the member invitation', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.contains('Inviter un membre de la collectivité').click({ force: true });

--- a/frontend_tests/cypress/e2e/project/switchtender/assigned/administration/canRevokeAMemberInvitation.cy.js
+++ b/frontend_tests/cypress/e2e/project/switchtender/assigned/administration/canRevokeAMemberInvitation.cy.js
@@ -10,7 +10,7 @@ describe('I can go to administration area of a project and revoke an invite for 
     it('goes to the administration tab of a project and revoke the member invitation', () => {
 
         cy.visit(`/project/${currentProject.pk}`)
-        cy.get('.project-navigation').children('li').contains('Administration').click({ force: true })
+        cy.get("[data-test-id='navigation-administration-tab']").click({force:true})
         cy.url().should('include', '/administration')
 
         cy.contains('Inviter un membre de la collectivité').click({ force: true });

--- a/urbanvitaliz/apps/projects/templates/projects/project/navigation.html
+++ b/urbanvitaliz/apps/projects/templates/projects/project/navigation.html
@@ -140,8 +140,9 @@
     {% if "invite_collaborators" in user_project_perms or "invite_advisors" in user_project_perms or "manage_advisors" in user_project_perms or "manage_collaborators" in user_project_perms or "change_project" in user_project_perms or is_staff %}
         <li>
             <a class="{% if administration_panel %} active{% endif %} align-items-center"
+               data-test-id="navigation-administration-tab"
                href="{% url 'projects-project-administration' project.pk %}">
-                <span class="text-nowrap">Administration</span>
+                <span class="text-nowrap">Paramètres</span>
             </a>
         </li>
     {% else %}


### PR DESCRIPTION
Carte trello https://trello.com/c/FeXVVxOW/1717-wording-changer-le-nom-de-longlet-administration-en-param%C3%A8tres