### PR TITLE
[crm] Fix padding CRM main

### DIFF
--- a/urbanvitaliz/frontend/src/css/crm.css
+++ b/urbanvitaliz/frontend/src/css/crm.css
@@ -131,6 +131,7 @@ main {
 }
 
 .crm-header {
+    padding-top: 66px;
     background-color: white;
     border-bottom: 1px solid #e1e1e1;
     margin-bottom: 0 !important;


### PR DESCRIPTION
Ceci est un hotfix pour résoudre un problème de layout qui mérite un fix de fond concernant le design de la barre d'entête de la vue CRM

## TODO

Je propose de créer une carte Trello pour traiter le problème de design/inté concernant la fonction de cet entête afin de permettre à l'utilisateur de voir le contexte malgré le scroll Jusqu'ici, ceci était implémenté grace à l'utilisation de la règle CSS `position: sticky`. Or cette règle est fragile lorsque l'élément ainsi positionné a du contenu de taille variable, car cette variation, lorsqu'elle grandit, couvre des éléments dans le flow css qui suit.
