### PR TITLE
Ajout de l'écran de mise à jour de la géoloc affinée après le formulaire de saisine

### DIFF
--- a/urbanvitaliz/apps/onboarding/tests.py
+++ b/urbanvitaliz/apps/onboarding/tests.py
@@ -128,9 +128,9 @@ def test_performing_onboarding_create_a_new_user_and_logs_in(request, client):
     assert project.owner == user
     assert project.submitted_by == user
 
-    next_url = urlencode(
-        {"next": reverse("survey-project-session", args=[project.id]) + "?first_time=1"}
-    )
+    next_args_for_project_location = urlencode({"next": reverse("survey-project-session", args=(project.pk,))})
+    next_url = urlencode({"next": f"{reverse('projects-project-location', args=(project.pk,))}?{next_args_for_project_location}"})
+    
     url = reverse("home-user-setup-password")
     assert response.url == (f"{url}?{next_url}")
 
@@ -176,7 +176,7 @@ def test_onboarding_fills_existing_user_and_profile_missing_info(request, client
 
     assert response.status_code == 302
     assert response["Location"].startswith(
-        reverse("survey-project-session", args=[project.id])
+        reverse("projects-project-location", args=[project.id])
     )
 
     user.refresh_from_db()
@@ -219,7 +219,7 @@ def test_onbording_do_not_replace_existing_user_email_when_logged_in(request, cl
 
     assert response.status_code == 302
     assert response["Location"].startswith(
-        reverse("survey-project-session", args=[project.id])
+        reverse("projects-project-location", args=[project.id])
     )
 
     user.refresh_from_db()  # fonctionne dans ce contexte

--- a/urbanvitaliz/apps/onboarding/views.py
+++ b/urbanvitaliz/apps/onboarding/views.py
@@ -108,17 +108,16 @@ def onboarding(request):
             del request.session["onboarding_existing_data"]
 
         if is_new_user:
-            # new user first have to setup her password and then complete the survey
+            # new user first have to setup her password and then complete the project location before the survey
             log_user(request, user, backend="django.contrib.auth.backends.ModelBackend")
-            next_url = (
-                reverse("survey-project-session", args=(project.id,)) + "?first_time=1"
-            )
+            next_args_for_project_location = urlencode({"next": reverse("survey-project-session", args=(project.pk,))})
+            next_url = f"{reverse('projects-project-location', args=(project.pk,))}?{next_args_for_project_location}"
             next_args = urlencode({"next": next_url})
             return redirect(f"{reverse('home-user-setup-password')}?{next_args}")
         else:
-            response = redirect("survey-project-session", project_id=project.id)
-            response["Location"] += "?first_time=1"
-            return response
+            # go to project location form before starting survey
+            next_args = urlencode({"next": reverse("survey-project-session", args=(project.pk,))})
+            return redirect(f"{reverse('projects-project-location', args=(project.pk,))}?{next_args}")
 
     return render(request, "onboarding/onboarding.html", locals())
 

--- a/urbanvitaliz/apps/projects/templates/projects/project/location.html
+++ b/urbanvitaliz/apps/projects/templates/projects/project/location.html
@@ -76,10 +76,7 @@
             <div x-ref="map-edit" id="map-edit" class="h-100 w-100"></div>
           </div>
           <div class="location-footer bg-white">
-            <form method="POST"
-                  action="{% url 'projects-project-location' project.pk %}"
-                  name="ProjectLocationForm"
-                  class="d-flex form-coordinates text-muted flex-row-reverse">
+            <form method="POST" action="" name="ProjectLocationForm" class="d-flex form-coordinates text-muted flex-row-reverse">
               {% csrf_token %}
               <!-- {{ form.as_p }} -->
               <fieldset class="d-flex w-100">

--- a/urbanvitaliz/apps/projects/views/detail.py
+++ b/urbanvitaliz/apps/projects/views/detail.py
@@ -383,6 +383,10 @@ def project_update_location(request, project_id=None):
         if form.is_valid():
             project = form.save()
 
+            next_url = request.GET.get("next", None)
+            if next_url:
+                return redirect(next_url)
+
             return redirect(
                 reverse("projects-project-detail-overview", args=[project.pk])
             )


### PR DESCRIPTION
Le formulaire de mise à jour de la géoloc est désormais proposé avant l'état des lieux.

Voici les nouveaux scénarios :
1) Utilisateur connecté : onboarding > location > survey
2) Utilisateur existant non connecté (reconnu par le mail) : onboarding > auth > onboarding > location > survey
3) Utilisateur non connu : onboarding > set-password > location > survey