### PR TITLE
Enlève les thématiques non utilisées de l'API, du nuage et de l'export CSV

### DIFF
--- a/urbanvitaliz/apps/crm/tests/test_topics.py
+++ b/urbanvitaliz/apps/crm/tests/test_topics.py
@@ -1,0 +1,62 @@
+import collections
+
+import pytest
+from django.contrib.sites import models as site_models
+from django.contrib.sites.shortcuts import get_current_site
+from django.utils import timezone
+from model_bakery import baker
+
+from urbanvitaliz.apps.projects import models as projects_models
+from urbanvitaliz.apps.tasks import models as tasks_models
+
+from .. import views
+
+########################################################################
+# topics tag cloud
+########################################################################
+
+
+@pytest.mark.django_db
+def test_compute_topics_tag_cloud(request):
+    site = get_current_site(request)
+    topic0 = baker.make(projects_models.Topic, site=site, name="topic0")
+    topic1 = baker.make(projects_models.Topic, site=site, name="topic1")
+    topic2 = baker.make(projects_models.Topic, site=site, name="topic2")
+    project = baker.make(projects_models.Project, sites=[site], name="theproject")
+    project.topics.set([topic0, topic2])
+    task = baker.make(
+        tasks_models.Task, project=project, site=site, topic=topic0, intent="thetask"
+    )
+
+    # topics on deleted project should not be counted
+    deleted_project = baker.make(
+        projects_models.Project,
+        sites=[site],
+        name="thedeletedproject",
+        deleted=timezone.now(),
+    )
+    deleted_project.topics.set([topic1])
+
+    # topics on deleted task should not be counted
+    deleted_task = baker.make(
+        tasks_models.Task,
+        project=project,
+        site=site,
+        topic=topic1,
+        intent="thedeletedtask",
+        deleted=timezone.now(),
+    )
+
+    topics = views.compute_topics_occurences(site)
+    assert topics == collections.OrderedDict(
+        [
+            (
+                "topic0",
+                (2, [("theproject", project.pk)], [("thetask", task.pk, project.pk)]),
+            ),
+            ("topic2", (1, [("theproject", project.pk)], [])),
+        ]
+    )
+
+
+# eof

--- a/urbanvitaliz/apps/crm/views.py
+++ b/urbanvitaliz/apps/crm/views.py
@@ -932,7 +932,7 @@ def compute_topics_occurences(site):
         (
             (topic.name, list(topic.projects.values_list("name", "id")))
             for topic in (
-                Topic.objects.filter(projects__sites=site)
+                Topic.objects.filter(projects__sites=site, projects__deleted=None)
                 .prefetch_related("projects")
                 .distinct()
             )
@@ -944,7 +944,7 @@ def compute_topics_occurences(site):
         (
             (topic.name, list(topic.tasks.values_list("intent", "id", "project__id")))
             for topic in (
-                Topic.objects.filter(tasks__site=site)
+                Topic.objects.filter(tasks__site=site, tasks__deleted=None)
                 .prefetch_related("tasks")
                 .distinct()
             )

--- a/urbanvitaliz/apps/projects/views/rest.py
+++ b/urbanvitaliz/apps/projects/views/rest.py
@@ -416,6 +416,8 @@ class TopicViewSet(viewsets.ReadOnlyModelViewSet):
         restrict_to = self.request.query_params.get("restrict_to", None)
         topics = models.Topic.objects.all()
         if restrict_to:
+            # Warning : make sure the models mapping here have a "deleted" field or change the code below ;)
+            # If not, a django.core.exceptions.FieldError will be throw.
             models_mapping = {
                 "projects": "projects",
                 "recommendations": "tasks",


### PR DESCRIPTION

## Problème

Les thématiques associées à une recommandation supprimée ou à un projet supprimé remontaient quand même.

## Solution

Un filtre sur les objets associés à la thématique pour vérifier qui n'ont pas de date de suppression.

J'ai également supprimé le filtre sur le site en cours car le `CurrentSiteManager` s'en charge déjà (ce qui produisait dans la requête un  ("projects_topic"."site_id" = 2 AND "projects_topic"."site_id" = 2) )