### PR TITLE
[fix] add conditional statement and logic for repeating challenges

### DIFF
--- a/urbanvitaliz/apps/projects/templates/projects/project/navigation.html
+++ b/urbanvitaliz/apps/projects/templates/projects/project/navigation.html
@@ -19,7 +19,7 @@
            padding: 0">
     <div class="position-relative d-flex align-items-center"
          id="overview-step-1">
-        {% if not position.is_advisor and not position.is_observer and is_regional_actor and overview %}
+        {% if position.is_advisor and not position.is_observer or is_regional_actor and overview %}
             {% include 'tutorial/tutorial_hint.html' %}
         {% endif %}
         {% if "list_projects" in user_site_perms or "view_project" in user_project_perms %}

--- a/urbanvitaliz/apps/training/tests/test_utils.py
+++ b/urbanvitaliz/apps/training/tests/test_utils.py
@@ -41,7 +41,7 @@ def test_user_challenge_returned_when_open_one_exists():
 @pytest.mark.django_db
 def test_user_challenge_returned_now_one_for_every_time_challenge():
     site = baker.make(site_models.Site)
-    user = baker.make(auth_models.User, last_login=timezone.now())
+    user = baker.make(auth_models.User)
     definition = baker.make(
         models.ChallengeDefinition, site=site, code="a-code", week_inactivity_repeat=0
     )
@@ -55,14 +55,13 @@ def test_user_challenge_returned_now_one_for_every_time_challenge():
     with settings.SITE_ID.override(site.pk):
         current = utils.get_challenge_for(user, definition.code)
 
-    # a new challenge is born
-    assert current and current != challenge and current.acquired_on is None
+    assert current is None
 
 
 @pytest.mark.django_db
 def test_user_challenge_not_repeated_before_inactivity_period():
     site = baker.make(site_models.Site)
-    user = baker.make(auth_models.User, last_login=timezone.now())
+    user = baker.make(auth_models.User)
     definition = baker.make(
         models.ChallengeDefinition, site=site, code="a-code", week_inactivity_repeat=1
     )
@@ -84,7 +83,7 @@ def test_user_challenge_not_repeated_before_inactivity_period():
 def test_user_challenge_repeated_when_over_inactivity_period():
     last_week = timezone.now() - datetime.timedelta(days=8)
     site = baker.make(site_models.Site)
-    user = baker.make(auth_models.User, last_login=last_week)
+    user = baker.make(auth_models.User)
     definition = baker.make(
         models.ChallengeDefinition, site=site, code="a-code", week_inactivity_repeat=1
     )


### PR DESCRIPTION
# Done

[Trello Ticket](https://trello.com/c/Vaja3kUi/1817-lanceur-de-didacticiel-pas-les-m%C3%AAmes-comportements-selon-les-portails)

ETQ Conseiller sur un projet : 
- J'ai accès au tutoriel si je ne l'ai pas acquis depuis la période renseignée dans la colonne `week_inactivity_repeat`

J'ai modifié l'implémentation initiale car elle se basait sur la dernière date de login or lorsqu'un user se logue cette date est remise à la date courante -> on ne sait donc plus quelle était la donnée initiale.

Actions à mettre en place coté BDD Prod pour vérifier que les autres sites soient bien pris en compte : 
- [ ]  `training_challengedefinition` doit être peuplée avec les sites MEC + Ecoquartier pour que les challenge puissent être déclenchés (mais doute sur le fait que ce soit voulu à vérifier ensemble)
- [ ]  `training_challengedefinition` paramétrer la période de répétition à 4 semaines (pour tous? à vérifier ensemble)