### PR TITLE
[fix] Add custom badge for challenge groups in user details page

### DIFF
--- a/urbanvitaliz/apps/crm/templates/crm/user_details.html
+++ b/urbanvitaliz/apps/crm/templates/crm/user_details.html
@@ -17,6 +17,11 @@
     html, body {
         scroll-padding-top: 240px;
     }
+    .custom-badge {
+      bottom: 1.5rem;
+      right: 0rem;
+      font-size: 0.5rem;
+    }
 </style>
 {% endblock %}
 
@@ -113,30 +118,29 @@
                         </div>
 
                         {% get_challenges_for crm_user acquired=None as challenges %}
+                        <div class="challenge-group">
+                          
+                        </div>
                         {% if challenges.count %}
 
                         <div class="d-flex justify-content-between align-items-end mt-2">
                             <svg class="mx-2 my-2" width="18" height="18" fill="currentColor">
                                 <use xlink:href="{% static 'svg/bootstrap-icons.svg' %}#trophy" />
                             </svg>
-
-                            {% for challenge in challenges.all %}
-                            {% with challenge.challenge_definition as definition %}
-                            {% if challenge.acquired_on %}
-                            <span data-toggle="tooltip" title="(ACQUIS) {{ definition.name }} - {{ challenge.acquired_on|naturalday }}" class="rounded-circle bg-light ">
-                                <svg class="text-success mx-2 my-2" width="16" height="16" fill="currentColor">
-                                    <use xlink:href="{% static 'svg/bootstrap-icons.svg' %}#{{ definition.icon_name|default:'award' }}" />
-                                </svg>
+                            
+                          {% regroup challenges.all|dictsort:"challenge_definition.name" by challenge_definition as challenge_groups %}
+                          {% for group in challenge_groups %}
+                          {% with group.list|dictsortreversed:"acquired_on"|first as last_acquire  %}
+                          <div class="position-relative">
+                            <span data-toggle="tooltip" title="(ACQUIS) {{ group.grouper }} ({{ group.list|length }})- {{ last_acquire.acquired_on|naturalday }}" class="rounded-circle bg-light ">
+                              <svg class="text-success mx-2 my-2" width="16" height="16" fill="currentColor">
+                                <use xlink:href="{% static 'svg/bootstrap-icons.svg' %}#{{ last_acquire.challenge_definition.icon_name|default:'award' }}" />
+                              </svg>
                             </span>
-                            {% else %}
-                            <span data-toggle="tooltip" title="(OUVERT) {{ definition.name }}" class="rounded-circle bg-black">
-                                <svg class="mx-2 my-2 text-white" width="16" height="16" fill="currentColor">
-                                    <use xlink:href="{% static 'svg/bootstrap-icons.svg' %}#{{ definition.icon_name|default:'award' }}" />
-                                </svg>
-                            </span>
-                            {% endif %}
-                            {% endwith %}
-                            {% endfor %}
+                            <span class="position-absolute badge text-bg-light custom-badge">{{ group.list|length }}</span>
+                          </div>
+                          {% endwith %}
+                          {% endfor %}
                         </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
# Done

[Trello Ticket](https://trello.com/c/T3X8l4kE/1875-crm-le-bouton-g%C3%A9rer-lutilisateur-ne-saffiche-pas-bien-selon-la-taille-ou-zoom-d%C3%A9cran)
Comme vu ensemble petite amélioration avant de reprendre le fonctionnement des challenges : 
![Capture d’écran 2024-01-30 à 17 57 56](https://github.com/betagouv/urbanvitaliz-django/assets/10596045/14e71b78-ce57-4c6a-bb68-8ac24d29fd0b)
